### PR TITLE
README: add newer, popular Bayesian inference pkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Angle Regression
 * [MCMCpack](http://mcmcpack.berkeley.edu/) - Markov chain Monte Carlo (MCMC) Package.
 * [R2WinBUGS](http://cran.r-project.org/web/packages/R2WinBUGS/index.html) - Running WinBUGS and OpenBUGS from R / S-PLUS.
 * [BRugs](http://cran.r-project.org/web/packages/BRugs/index.html) - R interface to the OpenBUGS MCMC software.
+* [rjags](http://cran.r-project.org/web/packages/rjags/index.html) - R interface to the JAGS MCMC library.
+* [rstan](http://mc-stan.org/rstan.html) - R interface to the Stan MCMC software.
 
 ## Finance
 *Packages for dealing with money.*


### PR DESCRIPTION
- These two packages are very popular for Bayesian computing
- Their main advantage over BUGS is that they're faster, cross-platform, and actively supported.
