### PR TITLE
Add xgboost package in Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Angle Regression
 * [tgp](http://cran.r-project.org/web/packages/tgp/index.html) - Bayesian treed Gaussian process models
 * [tree](http://cran.r-project.org/web/packages/tree/index.html) - Classification and regression trees
 * [varSelRF](http://cran.r-project.org/web/packages/varSelRF/index.html) - Variable selection using random forests
-* [xgboost](https://github.com/tqchen/xgboost/tree/master/R-package) - eXtreme Gradient Boosting
+* [xgboost](https://github.com/tqchen/xgboost/tree/master/R-package) - eXtreme Gradient Boosting Tree model, well known for its speed and performance.
 * [caret](http://caret.r-forge.r-project.org/) - Unified interface to ~150 ML algorithms in R.
 * [SuperLearner](https://github.com/ecpolley/SuperLearner) and [subsemble](http://cran.r-project.org/web/packages/subsemble/index.html) - Multi-algorithm ensemble learning packages.
 * [Introduction to Statistical Learning](http://www-bcf.usc.edu/~gareth/ISL/)


### PR DESCRIPTION
xgboost is a package implementing Gradient Boosting Tree model, which is first popular among the community of Kaggle, a machine learning competition website. It is well known for the fast speed and outstanding performance. There are numerous competitors won competitions or achieved high rankings with it. 

References:
[Winning Solution](http://www.kaggle.com/c/tradeshift-text-classification/forums/t/10901/solution-sharing)
[Popularity proof](https://www.kaggle.com/c/higgs-boson/forums/t/8184/public-starting-guide-to-get-above-3-60-ams-score)
