### PR TITLE
Replace jvmr website with GitHub url

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A curated list of awesome R frameworks, packages and software. Inspired by [awes
 *Packages for other languages.*
 
 * [rJava](http://cran.r-project.org/web/packages/rJava/) - Low-level R to Java interface.
-* [jvmr](http://dahl.byu.edu/software/jvmr/) - Integration of R, Java, and Scala.
+* [jvmr](https://github.com/cran/jvmr) - Integration of R, Java, and Scala.
 * [rJython](http://cran.r-project.org/web/packages/rJython/index.html) - R interface to Python via Jython.
 * [rPython](http://cran.r-project.org/web/packages/rPython/index.html) - Package allowing R to call Python.
 * [runr](https://github.com/yihui/runr) - Run Julia and Bash from R.


### PR DESCRIPTION
`jvmr` has been removed from CRAN. It means that any links to the source provided on the program page are invalid. GitHub repository from the other hand provides both source and url to the web page