### PR TITLE
Add Synapse client as a reproducible research tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ A curated list of awesome R frameworks, packages and software. Inspired by [awes
 * [Sweave](https://www.statistik.lmu.de/~leisch/Sweave/) - A package designed to write LaTeX reports using R.
 * [texreg](http://www.philipleifeld.de/software/texreg/texreg.html) - Formatting statistical models in LaTex and HTML.
 * [checkpoint](http://projects.revolutionanalytics.com/documents/rrt/rrtpkgs/) -   Install packages from snapshots on the checkpoint server.
-
+* [rSynapseClient](https://github.com/Sage-Bionetworks/rSynapseClient/) - programmatic interface to [Synapse](https://www.synapse.org/), a workspace that allows you to aggregate, describe, and share your research
+* 
 ## Web Technologies and Services
 *Packages to surf the web.*
 


### PR DESCRIPTION
The Synapse R client provides an interface to Synapse, a platform that allows you to aggregate, describe, and share your research. It can also be used with other tools on this list like knitr to provide Wiki pages to describe files or projects.
