### PR TITLE
Added links to two NLP packages: topicmodels and syuzhet

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Angle Regression
 * [Rwordseg](http://jliblog.com/app/rwordseg) - Chinese word segmentation.
 * [NLP](http://cran.r-project.org/web/packages/NLP/index.html) - Basic functions for Natural Language Processing.
 * [LDAvis](https://github.com/cpsievert/LDAvis) - Interactive visualization of topic models.
+* [topicmodels](https://cran.r-project.org/web/packages/topicmodels/index.html) - Topic modeling interface to the C code developed by by David M. Blei for Topic Modeling (Latent Dirichlet Allocation (LDA), and Correlated Topics Models (CTM)).
+* [syuzhet](https://cran.r-project.org/web/packages/syuzhet/index.html) - Extracts sentiment from text using three different sentiment dictionaries.
 
 ## Bayesian
 *Packages for Bayesian Inference.*


### PR DESCRIPTION
Thank you for compiling this great list. I have recently been working on some NLP in R and there are two packages that I have found to be useful: [topicmodels](https://cran.r-project.org/web/packages/topicmodels/index.html), which provides code for implementing LDA topic models, and [syuzhet](https://cran.r-project.org/web/packages/syuzhet/index.html) which provides three different sentiment dictionaries. I thought they were relatively easy to use and they were really useful for me so I thought I would pass them along!