### PR TITLE
Add subsection: Free online courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,10 @@ Angle Regression
 
 - [swirl](http://swirlstats.com/) - An interactive R tutorial directly in your R console.
 
+*Free online Courses.*
+
+- [R Programming] (https://www.coursera.org/course/rprog) -  Learn how to program in R (Johns Hopkins University).
+
 # Resources
 
 Where to discover new R-esources.


### PR DESCRIPTION
I included the the R programming course from Johns Hokins University.

I Would also suggest that we move the DataCamp to this subsection and also include [Try R] (http://tryr.codeschool.com/).