### PR TITLE
Add the scatterD3 HTML widget package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A curated list of awesome R frameworks, packages and software. Inspired by [awes
 * [Leaflet](http://rstudio.github.io/leaflet/) - One of the most popular JavaScript libraries interactive maps.
 * [MetricsGraphics](http://hrbrmstr.github.io/metricsgraphics/) - Enables easy creation of D3 scatterplots, line charts, and histograms.
 * [networkD3](http://christophergandrud.github.io/networkD3/) - D3 JavaScript Network Graphs from R.
+* [scatterD3](https://github.com/juba/scatterD3) - Interactive scatterplots with D3.
 * [plotly](https://github.com/ropensci/plotly) - Interactive ggplot2 and Shiny plotting with [plot.ly](https://plot.ly).
 * [rCharts](https://github.com/ramnathv/rCharts) - Interactive JS Charts from R.
 * [rbokeh](http://hafen.github.io/rbokeh/) - R Interface to [Bokeh](http://bokeh.pydata.org/en/latest/).


### PR DESCRIPTION
Hi,

Just a pull request suggestion to add the scatterD3 package, which provides interactive scatterplots using htmlwidgets and d3.js. 

A demo of the package integratin with shiny can be found here : https://juba.shinyapps.io/scatterD3_shiny_app

And the introduction vignette is here :
http://rpubs.com/juba/scatterD3

Feel free to accept or reject this PR if you find the package useful enough to be in your list, or not.

Thanks !

Julien