### PR TITLE
Added ggfortify to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A curated list of awesome R frameworks, packages and software. Inspired by [awes
 *Packages for showing data.*
 
 * [ggplot2](https://github.com/hadley/ggplot2) - An implementation of the Grammar of Graphics.
+* [ggfortify](https://github.com/sinhrks/ggfortify) - A unified interface to ggplot2 popular statistical packages using one line of code. 
 * [lattice](http://lattice.r-forge.r-project.org/) - A powerful and elegant high-level data visualization system.
 * [rgl](http://cran.r-project.org/web/packages/rgl/index.html) - 3D visualization device system for R.
 * [Cairo](http://cran.r-project.org/web/packages/Cairo/index.html) - R graphics device using cairo graphics library for creating high-quality display output.


### PR DESCRIPTION
ggfortify is an easy-to-use R visualization package that gets popular recently. 

A unified interface to ggplot2 popular statistical packages using one line of code. 