### PR TITLE
Added Rdocumentation to website section

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Where to discover new R-esources.
 * [R-users](https://www.r-users.com/) - A job board for R users (and the people who are looking to hire them)
 * [R Cookbook](http://www.cookbook-r.com/) - A problem-oriented website that supports the [R Graphics Cookbook](http://shop.oreilly.com/product/0636920023135.do).
 * [tryR](http://tryr.codeschool.com/) - A quick course for getting started with R.
+* [RDocumentation](https://www.rdocumentation.org/) - Search through all CRAN, Bioconductor, Github packages and their archives with RDocumentation.
 
 ## Books
 


### PR DESCRIPTION
Rdocumentation.org aggregates R documentation from CRAN, BioConductor, and GitHub. It also allows you to rank R packages by popularity and post community examples.  