### PR TITLE
Add R Suite to R Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Angle Regression
 * [covr](https://github.com/jimhester/covr) - Test coverage for your R package and (optionally) upload the results to [coveralls](https://coveralls.io/) or [codecov](https://codecov.io/).
 * [lintr](https://github.com/jimhester/lintr) - Static code analysis for R to enforce code style.
 * [staticdocs](https://github.com/hadley/staticdocs) - Generate static html documentation for an R package.
+* [R Suite](http://rsuite.io/) - Manage large scale R software projects and environments.
 
 ## Logging
 *Packages for Logging*


### PR DESCRIPTION
R Suite is to fill gap in "out-of-the-box" R to meet Enteprise requirements for large scale software development. It supports:
- isolated reproducible projects with controlled dependencies and configuration,
- separation of business, infrastructural and domain logic,
- gives full control over development, test and production environment,
- management of local CRAN repos