### PR TITLE
Updated a few URLs + handbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Where to discover new R-esources.
 
 ### Free and Online
 
-* [_R for Data Science_ by Garrett Grolemund & Hadley Wickham](http://r4ds.had.co.nz/) - Free book from RStudio developers with emphasis on data science workflow.
+* [_R for Data Science_, 2nd ed. by Garrett Grolemund & Hadley Wickham](https://r4ds.hadley.nz/) - Free book from RStudio developers with emphasis on data science workflow.
 * [_R Cookbook_ by Winston Chang](http://www.cookbook-r.com/) - A problem-oriented online book that supports his [R Graphics Cookbook, 2nd ed. (2018)](http://shop.oreilly.com/product/0636920063704.do).
 * [_Advanced R_, 2nd ed. by Hadley Wickham (2019) <img class="emoji" alt="heart" src="https://cdn.jsdelivr.net/gh/qinwf/awesome-R@3c66da6e291bcc0520b1649125b0bed750896a9a/heart.png" height="20" align="absmiddle" width="20">](https://adv-r.hadley.nz/) - An online version of the Advanced R book.
 * [_R Packages_, 2nd ed. by Hadley Wickham & Jennifer Bryan](https://r-pkgs.org/) - A book (in paper and website formats) on writing R packages.
@@ -616,6 +616,8 @@ Where to discover new R-esources.
   * [_R Programming for Data Science_ by Roger D. Peng (2019)](https://leanpub.com/rprogramming) - More advanced data analysis that relies on R programming.
   * [_Report Writing for Data Science in R_ by Roger D. Peng (2019)](https://leanpub.com/reportwriting) - R-based methods for reproducible research and report generation.
 * [_R for SAS and SPSS users_ by Bob Muenchen (2012)](http://r4stats.com/books/free-version/) - An excellent resource for users already familiar with SAS or SPSS.
+* [_R Cookbook_, 2nd ed. by JD Long & Paul Teetor (2019)](https://rc2e.com/) - A quick and simple introduction to conducting many common statistical tasks with R.
+* [_Introduction to Data Science_ by Rafael Irizarry (2022)](http://rafalab.dfci.harvard.edu/dsbook/) - A very good introduction to R and the tidyverse.
 * [_Introduction to Statistical Learning with Application in R_ by Gareth James et al. (2017)](http://faculty.marshall.usc.edu/gareth-james/ISL/) - A simplified and "operational" version of *The Elements of Statistical Learning*. Free softcopy provided by its authors.
 * [_The R Inferno_ by Patrick Burns (2011)](http://www.burns-stat.com/pages/Tutor/R_inferno.pdf) - Patrick Burns gives insight into R's ins and outs along with its quirks!
 * [_Efficient R Programming_ by Colin Gillespie & Robin Lovelace (2017)](https://csgillespie.github.io/efficientR/) - An online version of the O’Reilly book: Efficient R Programming.
@@ -624,7 +626,6 @@ Where to discover new R-esources.
 ### Paid
 
 * [The Art of R Programming](http://shop.oreilly.com/product/9781593273842.do) - It's a good resource for systematically learning fundamentals such as types of objects, control statements, variable scope, classes and debugging in R.
-* [_R Cookbook_, 2nd ed. by JD Long & Paul Teetor (2019)](http://shop.oreilly.com/product/0636920174851.do) - A quick and simple introduction to conducting many common statistical tasks with R.
 * [R in Action](http://www.manning.com/kabacoff2/) - This book aims at all levels of users, with sections for beginning, intermediate and advanced R ranging from "Exploring R data structures" to running regressions and conducting factor analyses.
 * [_Use R!_ Series by Springer](http://www.springer.com/series/6991?detailsPage=titles) - This series of inexpensive and focused books from Springer publish shorter books aimed at practitioners. Books can discuss the use of R in a particular subject area, such as Bayesian networks, ggplot2 and Rcpp.
 * [Learning R Programming](https://www.packtpub.com/big-data-and-business-intelligence/learning-r-programming) - Learning R as a programming language from basics to advanced topics.

--- a/misc/posts.md
+++ b/misc/posts.md
@@ -12,7 +12,7 @@
 ## 3/2016
 
 1. [Rbitrary Standards](https://ironholds.org/projects/rbitrary/)<br/>@ Oliver Keyes **#R #FAQ** <br/> This is an alternate FAQ for R. <br/> &nbsp;
-1. [Submitting packages to CRAN](http://f.briatte.org/r/submitting-packages-to-cran) <br/>@ François Briatte **#CRAN #package** <br/> This note lists a few of the mistakes that one can make before submitting a package to CRAN. <br/> &nbsp;
+1. [Submitting packages to CRAN](https://f.briatte.org/r/submitting-packages-to-cran) <br/>@ François Briatte **#CRAN #package** <br/> This note lists a few of the mistakes that one can make before submitting a package to CRAN. <br/> &nbsp;
 1. [EigenCoder: Programming Stereotypes](http://trestletech.com/2016/03/09/eigencoder/) <br/>@ Jeff Allen **#fun #visual**  <br/> There are a lot of stereotypes in the programming community. Well it turns out that some of these might be true. <br/> &nbsp;
 1. [BallR: Interactive NBA Shot Charts with R and Shiny](http://toddwschneider.com/posts/ballr-interactive-nba-shot-charts-with-r-and-shiny/)  <br/>@ Todd W. Schneider **#shiny #NBA** <br/> Make your own shot charts for any NBA player dating back to 1996. <br/> &nbsp;
 1. [It’s not the p-values’ fault – reflections on the recent ASA statement (+relevant R resources)](http://www.r-statistics.com/2016/03/its-not-the-p-values-fault-reflections-on-the-recent-asa-statement/)  <br/>@ Tal Galili & Yoav Benjamini **#p-value #theory**   <br/> This post highlights points raised by Yoav Benjamini in his official response to the ASA statement, as well as offers a list of relevant R resources. <br/> &nbsp;
@@ -20,11 +20,11 @@
 
 ## 2/2016
 
-1. [Sustainable code for social scientists](http://f.local/r/sustainable-code-for-social-scientists) <br/>@ François Briatte **#reproducible #code**  <br/> &nbsp;
+1. [Sustainable code for social scientists](https://f.briatte.org/r/sustainable-code-for-social-scientists) <br/>@ François Briatte **#reproducible #code**  <br/> &nbsp;
 
 ## 1/2016
 
-1. [String manipulations on full names](http://f.local/r/string-manipulation-on-full-names)  <br/>@ François Briatte **#string #preprocess** <br/> This note shows how to use the stringr package to clean a list of full names. <br/> &nbsp;
+1. [String manipulations on full names](https://f.briatte.org/r/string-manipulation-on-full-names)  <br/>@ François Briatte **#string #preprocess** <br/> This note shows how to use the stringr package to clean a list of full names. <br/> &nbsp;
 
 ## 1/2015
 


### PR DESCRIPTION
I recently [assembled](https://github.com/briatte/dsr/wiki/Readings) a small list of good R handbooks. Many of them are free online, and are also available as printed books in parallel.

The PR contains only a few fixes and one addition (Irizarry, which is more up-to-date than the Peng books in the list).

Let me know if you want me to submit more. I can also remove older resources when relevant.